### PR TITLE
Remote Syslog service provider needs to be set to 'upstart'. 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,8 +61,9 @@ class papertrail (
   }
 
   service { 'remote_syslog':
-    ensure  => running,
-    require => File['remote_syslog upstart script'],
+    ensure   => running,
+    provider => 'upstart',
+    require  => File['remote_syslog upstart script'],
   }
 
   file { 'remote_syslog config':


### PR DESCRIPTION
Service provider needs to be set to 'upstart' or Puppet will fail.

Tested on Puppet 2.7.11
