### PR TITLE
Using instance variables in templates

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,17 +60,30 @@ class papertrail (
     path   => '/etc/init/remote_syslog.conf',
   }
 
-  service { 'remote_syslog':
-    ensure   => running,
-    provider => 'upstart',
-    require  => File['remote_syslog upstart script'],
+  if !empty($extra_logs) {
+  }
+
+  $remote_syslog_status = empty($extra_logs) ? {
+    true => stopped,
+    false  => running
+  }
+
+  $remote_syslog_file = empty($extra_logs) ? {
+    true => absent,
+    false  => file
   }
 
   file { 'remote_syslog config':
-    ensure  => file,
+    ensure  => $remote_syslog_file,
     content => template('papertrail/log_files.yml.erb'),
     path    => '/etc/log_files.yml',
     require => File['remote_syslog upstart script'],
     notify  => Service['remote_syslog'],
+  }
+
+  service { 'remote_syslog':
+    ensure      => $remote_syslog_status,
+    provider    => 'upstart',
+    require     => File['remote_syslog upstart script'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,9 +60,6 @@ class papertrail (
     path   => '/etc/init/remote_syslog.conf',
   }
 
-  if !empty($extra_logs) {
-  }
-
   $remote_syslog_status = empty($extra_logs) ? {
     true => stopped,
     false  => running

--- a/templates/log_files.yml.erb
+++ b/templates/log_files.yml.erb
@@ -1,8 +1,8 @@
 files: 
-<% extra_logs.each do |log_file| -%>
+<% @extra_logs.each do |log_file| -%>
   - <%= log_file %>
 <% end -%>
 ssl_server_cert: /etc/papertrail.crt
 destination:
-  host: <%= log_host %>
-  port: <%= log_port %>
+  host: <%= @log_host %>
+  port: <%= @log_port %>

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -3,4 +3,4 @@ $ActionSendStreamDriver gtls
 $ActionSendStreamDriverMode 1
 $ActionSendStreamDriverAuthMode x509/name
 
-*.*	@@<%= log_host %>:<%= log_port %>
+*.*	@@<%= @log_host %>:<%= @log_port %>


### PR DESCRIPTION
The old practice of using methods instead of instance variables for templates is
deprecated in Puppet 3 and will be removed in Puppet 4. See
http://docs.puppetlabs.com/guides/templating.html#referencing-variables for more
information.
