### PR TITLE
Added ruby-dev package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,10 @@ class papertrail (
     ensure => present,
   }
 
+  package { 'ruby-dev':
+    ensure => present,
+  }
+
   package { 'remote_syslog':
     ensure   => present,
     provider => 'gem',


### PR DESCRIPTION
Tested on Ubuntu 12.04 & 13.04, ruby-dev package is required for building the remote_syslog gem. 
