### PR TITLE
Only install packages if not already installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,22 +32,30 @@ class papertrail (
     notify => Service['rsyslog'],
   }
 
-  package { 'gcc':
-    ensure => present,
+  if ! defined(Package['gcc'])  {
+    package { 'gcc':
+      ensure => present,
+    }
   }
 
-  package { 'rubygems':
-    ensure => present,
+  if ! defined(Package['rubygems'])  {
+    package { 'rubygems':
+      ensure => present,
+    }
   }
 
-  package { 'libssl-dev':
-    ensure => present,
+  if ! defined(Package['libssl-dev'])  {
+    package { 'libssl-dev':
+      ensure => present,
+    }
   }
 
-  package { 'ruby-dev':
-    ensure => present,
+  if ! defined(Package['ruby-dev'])  {
+    package { 'ruby-dev':
+      ensure => present,
+    }
   }
-
+  
   package { 'remote_syslog':
     ensure   => present,
     provider => 'gem',


### PR DESCRIPTION
For example, I already have installed ruby-dev as part of another module. This module should not assume it is the only one installing packages with said name
