### PR TITLE
Not working on Ubuntu 14.04

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,16 +32,19 @@ class papertrail (
     notify => Service['rsyslog'],
   }
 
-  ensure_packages(['gcc', 'rubygems', 'libssl-dev', 'ruby-dev'])
+  if $::osfamily == 'Debian' and $::operatingsystemrelease == '12.04' {
+    $deps = ['build-essential','rubygems', 'libssl-dev', 'ruby-dev']
+  }
+  else {
+    $deps = ['build-essential','libssl-dev', 'ruby-dev']
+  }
+
+  ensure_packages($deps)
 
   package { 'remote_syslog':
     ensure   => present,
     provider => 'gem',
-    require  => [
-      Package['rubygems'],
-      Package['gcc'],
-      Package['libssl-dev'],
-    ],
+    require  => Package[$deps],
   }
 
   file { 'remote_syslog upstart script':


### PR DESCRIPTION
With the new LTS release of ubuntu, the rubygems package was removed.

A quick fix would be:

```
if $::osfamily == 'Debian' and $::operatingsystemrelease == '12.04' {
  $deps = ['gcc','rubygems', 'libssl-dev', 'ruby-dev']
}
else {
  $deps = ['gcc','libssl-dev', 'ruby-dev']
}
```
